### PR TITLE
MC-32581: [MSI][MFTF] AdminNotifyQuantityUseDefaultAppliedToVirtualPr…

### DIFF
--- a/InventoryAdminUi/Test/Mftf/Test/AdminNotifyQuantityUseDefaultAppliedToVirtualProductOnConfigurationAdminPageTest.xml
+++ b/InventoryAdminUi/Test/Mftf/Test/AdminNotifyQuantityUseDefaultAppliedToVirtualProductOnConfigurationAdminPageTest.xml
@@ -107,7 +107,7 @@
 
         <fillField selector="{{AdminProductSourcesGrid.rowQty('0')}}" userInput="{{VirtualMsiProduct.quantity}}" stepKey="fillSourceQty1"/>
 
-        <actionGroup ref="AdminFormSaveAndClose" stepKey="saveAndCloseCreatedProduct1"/>
+        <actionGroup ref="SaveProductFormActionGroup" stepKey="saveAndCloseCreatedProduct1"/>
 
         <comment userInput="Change config value for 'Notify for Quantity Below'." stepKey="setNotifyForQuantityBelowToFiveComment1"/>
         <magentoCLI command="config:set cataloginventory/item_options/notify_stock_qty 5" stepKey="setNotifyForQuantityBelowToFive1"/>


### PR DESCRIPTION
## Scope

### Bug - P1
* [MC-32581](https://jira.corp.magento.com/browse/MC-32581) [MSI][MFTF] AdminNotifyQuantityUseDefaultAppliedToVirtualProductOnConfigurationAdminPageTest fails because of bad design 

### Bamboo CI builds

- Not Required for MFTF tests delivery

### Linked Pull Requests

### CE Checklist

- [ ] PR is green on M2 Quality Portal
- [ ] Jira issues have accurate summary, meaningful description and have links to relevant documentation at the story/task level
- [ ] Semantic Version build failure is approved by architect (if build is red) <Architect Name>
- [ ] Pull Request approved by architect <Architect Name>
- [ ] Pull Request quality review performed by <name>
- [ ] All unstable functional acceptance tests are isolated (if any)
- [ ] All linked Zephyr tests are approved by PO and have Ready to Use status
- [ ] Travis CI build is green (for mainline CE only)
- [ ] Jenkins Unit, Extended FAT CE, Extended FAT EE and Extended FAT B2B builds are green
